### PR TITLE
Fix compiler error on x86 platform.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,8 @@ impl Semalock {
                 Err(e) => return Err(e.to_string()),
             };
             let sem_timeout = libc::timespec {
-                tv_sec: (now_elapsed_epoch.as_secs() + sem_timeout_seconds) as i64,
-                tv_nsec: i64::from(now_elapsed_epoch.subsec_nanos()),
+                tv_sec: (now_elapsed_epoch.as_secs() + sem_timeout_seconds) as libc::time_t,
+                tv_nsec: (now_elapsed_epoch.subsec_nanos()) as libc::c_long,
             };
             let call_status = unsafe { libc::sem_timedwait(self.sem, &sem_timeout) };
 


### PR DESCRIPTION
Type missmatched on x86 platform.

```shell
error[E0308]: mismatched types
   --> semalock_org/src/lib.rs:129:25
    |
129 |                 tv_sec: (now_elapsed_epoch.as_secs() + sem_timeout_seconds) as i64,
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `i64`

error[E0308]: mismatched types
   --> semalock_org/src/lib.rs:130:26
    |
130 |                 tv_nsec: i64::from(now_elapsed_epoch.subsec_nanos()),
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `i64`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0308`.
```